### PR TITLE
fix: sanitize characters in log output to prevent garbled log screen

### DIFF
--- a/flutter_app/lib/services/gateway_service.dart
+++ b/flutter_app/lib/services/gateway_service.dart
@@ -101,12 +101,13 @@ class GatewayService {
   void _subscribeLogs() {
     _logSubscription?.cancel();
     _logSubscription = NativeBridge.gatewayLogStream.listen((log) {
-      final logs = [..._state.logs, log];
+      final sanitizedLog = log.replaceAll(AppConstants.ansiEscape, '');
+      final logs = [..._state.logs, sanitizedLog];
       if (logs.length > 500) {
         logs.removeRange(0, logs.length - 500);
       }
       String? dashboardUrl;
-      final cleanLog = _cleanForUrl(log);
+      final cleanLog = _cleanForUrl(sanitizedLog);
       final urlMatch = _tokenUrlRegex.firstMatch(cleanLog);
       if (urlMatch != null) {
         dashboardUrl = urlMatch.group(0);


### PR DESCRIPTION
# Summary

This PR sanitizes the log entries. This in turn improves the readability of the log view in the app. As a by-product it is also a micro optimization for memory usage.

| before (with e.g. `[90m`) | after (without!) |
| ------ | ------- |
| <img width="353" height="740" alt="unsanitized" src="https://github.com/user-attachments/assets/df77cfb6-3ae6-4815-90bd-a0608a3dd255" /> | <img width="353" height="740" alt="sanitized" src="https://github.com/user-attachments/assets/a552561c-5cec-4a01-9d1a-3318d5695a3e" /> |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes log output by stripping ANSI escape codes to prevent garbled characters in the log screen and improve readability. URL detection now runs on the sanitized text, with a slight memory win.

<sup>Written for commit 86ac28b005a6849799625011cce098c23db2152b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced log display by removing formatting codes from stored log messages.
  * Improved URL extraction reliability by sanitizing logs before pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->