### PR TITLE
Add OpenClaw tgz install path and arm64 packaging scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,8 @@ proot-distro login ubuntu
 apt update && apt install -y curl
 curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
 apt install -y nodejs
-npm install -g openclaw
+# Custom build (.tgz) first, fallback to npm registry
+npm install -g "https://github.com/TomGoh/openclaw/releases/download/metaos/openclaw-2026.3.24.tgz" || npm install -g openclaw
 ```
 
 ### 3. Create Bionic Bypass

--- a/flutter_app/lib/constants.dart
+++ b/flutter_app/lib/constants.dart
@@ -36,6 +36,10 @@ class AppConstants {
   static const String nodeVersion = '22.14.0';
   static const String nodeBaseUrl =
       'https://nodejs.org/dist/v$nodeVersion/node-v$nodeVersion-linux-';
+  // Fixed OpenClaw tarball URL (download first, fallback to npm registry).
+  static const String openclawTgzUrl =
+      'https://gitee.com/clt201114/mygitee/releases/download/v1.0.0/openclaw-2026.3.24.tgz';
+  static const String openclawNpmPackage = 'openclaw';
 
   static String getNodeTarballUrl(String arch) {
     switch (arch) {

--- a/flutter_app/lib/screens/splash_screen.dart
+++ b/flutter_app/lib/screens/splash_screen.dart
@@ -22,6 +22,17 @@ class _SplashScreenState extends State<SplashScreen>
   late final AnimationController _fadeController;
   late final Animation<double> _fadeAnimation;
 
+  String _shellQuote(String value) => "'${value.replaceAll("'", r"'\''")}'";
+
+  String _openclawInstallCommand(String nodeRun, String npmCli) {
+    if (AppConstants.openclawTgzUrl.isEmpty) {
+      return '$nodeRun $npmCli install -g ${AppConstants.openclawNpmPackage}';
+    }
+    final tgz = _shellQuote(AppConstants.openclawTgzUrl);
+    return '$nodeRun $npmCli install -g $tgz || '
+        '$nodeRun $npmCli install -g ${AppConstants.openclawNpmPackage}';
+  }
+
   @override
   void initState() {
     super.initState();
@@ -156,7 +167,7 @@ class _SplashScreenState extends State<SplashScreen>
                 const nodeRun = 'node $wrapper';
                 const npmCli = '/usr/local/lib/node_modules/npm/bin/npm-cli.js';
                 await NativeBridge.runInProot(
-                  '$nodeRun $npmCli install -g openclaw',
+                  _openclawInstallCommand(nodeRun, npmCli),
                   timeout: 1800,
                 );
                 await NativeBridge.createBinWrappers('openclaw');

--- a/flutter_app/lib/services/bootstrap_service.dart
+++ b/flutter_app/lib/services/bootstrap_service.dart
@@ -7,6 +7,17 @@ import 'native_bridge.dart';
 class BootstrapService {
   final Dio _dio = Dio();
 
+  String _shellQuote(String value) => "'${value.replaceAll("'", r"'\''")}'";
+
+  String _openclawInstallCommand(String nodeRun, String npmCli) {
+    if (AppConstants.openclawTgzUrl.isEmpty) {
+      return '$nodeRun $npmCli install -g ${AppConstants.openclawNpmPackage}';
+    }
+    final tgz = _shellQuote(AppConstants.openclawTgzUrl);
+    return '$nodeRun $npmCli install -g $tgz || '
+        '$nodeRun $npmCli install -g ${AppConstants.openclawNpmPackage}';
+  }
+
   void _updateSetupNotification(String text, {int progress = -1}) {
     try {
       NativeBridge.updateSetupNotification(text, progress: progress);
@@ -261,7 +272,7 @@ class BootstrapService {
       ));
       // Install openclaw — fork/exec works now with our Termux-matching proot.
       await NativeBridge.runInProot(
-        '$nodeRun $npmCli install -g openclaw',
+        _openclawInstallCommand(nodeRun, npmCli),
         timeout: 1800,
       );
 

--- a/lib/installer.js
+++ b/lib/installer.js
@@ -12,6 +12,11 @@ const BASHRC = path.join(HOME, '.bashrc');
 const ZSHRC = path.join(HOME, '.zshrc');
 const PROOT_ROOTFS = '/data/data/com.termux/files/usr/var/lib/proot-distro/installed-rootfs';
 const PROOT_UBUNTU_ROOT = path.join(PROOT_ROOTFS, 'ubuntu', 'root');
+const OPENCLAW_TGZ_URL = 'https://gitee.com/clt201114/mygitee/releases/download/v1.0.0/openclaw-2026.3.24.tgz';
+
+function getOpenClawInstallCommand() {
+  return `npm install -g "${OPENCLAW_TGZ_URL}" || npm install -g openclaw`;
+}
 
 export function checkDependencies() {
   const deps = {
@@ -87,11 +92,12 @@ export function installOpenClaw() {
   console.log('Installing OpenClaw...');
 
   try {
-    execSync('npm install -g openclaw', { stdio: 'inherit' });
+    execSync(getOpenClawInstallCommand(), { stdio: 'inherit' });
     return true;
   } catch (err) {
     console.error('Failed to install OpenClaw:', err.message);
-    console.log('You may need to install it manually: npm install -g openclaw');
+    console.log(`You may need to install it manually: npm install -g "${OPENCLAW_TGZ_URL}"`);
+    console.log('Fallback/manual command: npm install -g openclaw');
     return false;
   }
 }
@@ -201,13 +207,14 @@ export function installUbuntu() {
 
 export function setupProotUbuntu() {
   console.log('Setting up Node.js and OpenClaw in Ubuntu...');
+  const installCommand = `npm install -g "${OPENCLAW_TGZ_URL}" || npm install -g openclaw`;
 
   const setupScript = `
     apt update && apt upgrade -y
     apt install -y curl wget git
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
     apt install -y nodejs
-    npm install -g openclaw
+    ${installCommand}
   `;
 
   try {

--- a/scripts/build-apk-only-arm64-v8a.sh
+++ b/scripts/build-apk-only-arm64-v8a.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Build the OpenClaw Flutter APK (arm64-v8a only)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR/.."
+FLUTTER_DIR="$PROJECT_DIR/flutter_app"
+
+echo "=== OpenClaw APK Build (arm64-v8a only) ==="
+echo ""
+
+# Step 1: Fetch proot binaries if not present
+if [ ! -f "$FLUTTER_DIR/android/app/jniLibs/arm64-v8a/libproot.so" ]; then
+    echo "[1/3] Fetching PRoot binaries (arm64-v8a only)..."
+    bash "$SCRIPT_DIR/fetch-proot-binaries-only-arm64-v8a.sh"
+else
+    echo "[1/3] PRoot binaries already present (arm64-v8a)"
+fi
+echo ""
+
+# Step 2: Get Flutter dependencies
+echo "[2/3] Getting Flutter dependencies..."
+cd "$FLUTTER_DIR"
+flutter pub get
+echo ""
+
+# Step 3: Build APK
+echo "[3/3] Building release APK (arm64-v8a)..."
+flutter build apk --release --target-platform android-arm64
+echo ""
+
+APK_PATH="$FLUTTER_DIR/build/app/outputs/flutter-apk/app-release.apk"
+if [ -f "$APK_PATH" ]; then
+    echo "=== Build Successful ==="
+    echo "APK: $APK_PATH"
+    echo "Size: $(du -h "$APK_PATH" | cut -f1)"
+    echo ""
+    echo "Install: adb install $APK_PATH"
+else
+    echo "=== Build Failed ==="
+    exit 1
+fi

--- a/scripts/fetch-proot-binaries-only-arm64-v8a.sh
+++ b/scripts/fetch-proot-binaries-only-arm64-v8a.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Fetch pre-compiled PRoot binaries from Termux packages for Android.
+# Extracts proot, libtalloc, and loader from Termux .deb packages.
+# Places them in jniLibs/<abi>/lib*.so so Android auto-extracts
+# them to nativeLibraryDir with execute permission (bypasses W^X).
+#
+# At runtime, BootstrapManager copies libtalloc.so → libtalloc.so.2
+# (matching the SONAME proot expects) in a writable directory.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+JNILIBS_DIR="$SCRIPT_DIR/../flutter_app/android/app/src/main/jniLibs"
+TMP_DIR=$(mktemp -d)
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TERMUX_REPO="https://packages.termux.dev/apt/termux-main"
+
+# Fetch a Termux package and extract binaries
+fetch_termux_pkg() {
+    local pkg_name="$1"
+    local deb_arch="$2"
+    local extract_dir="$3"
+
+    echo "    Fetching $pkg_name for $deb_arch..."
+
+    # Get package filename from repo index
+    local pkg_url
+    pkg_url=$(curl -fsSL "${TERMUX_REPO}/dists/stable/main/binary-${deb_arch}/Packages" \
+        | grep -A 20 "^Package: ${pkg_name}$" \
+        | grep "^Filename:" \
+        | head -1 \
+        | awk '{print $2}')
+
+    if [ -z "$pkg_url" ]; then
+        echo "    WARN: $pkg_name not found in Termux repo for $deb_arch"
+        return 1
+    fi
+
+    local deb_file="$TMP_DIR/${pkg_name}-${deb_arch}.deb"
+    curl -fsSL "${TERMUX_REPO}/${pkg_url}" -o "$deb_file"
+
+    mkdir -p "$extract_dir"
+    cd "$extract_dir"
+    ar x "$deb_file"
+    # Handle different compression formats
+    if [ -f data.tar.xz ]; then
+        tar xf data.tar.xz
+    elif [ -f data.tar.gz ]; then
+        tar xf data.tar.gz
+    elif [ -f data.tar.zst ]; then
+        zstd -d data.tar.zst -o data.tar && tar xf data.tar
+    else
+        tar xf data.tar.* 2>/dev/null
+    fi
+    cd "$SCRIPT_DIR"
+}
+
+fetch_for_abi() {
+    local jni_abi="$1"
+    local deb_arch="$2"
+    local out_dir="$JNILIBS_DIR/$jni_abi"
+    local extract_base="$TMP_DIR/extract-$jni_abi"
+
+    mkdir -p "$out_dir"
+    echo "  [$jni_abi]"
+
+    # Fetch proot package (includes proot binary + loader)
+    local proot_dir="$extract_base/proot"
+    if ! fetch_termux_pkg "proot" "$deb_arch" "$proot_dir"; then
+        return 1
+    fi
+
+    # Fetch libtalloc package
+    local talloc_dir="$extract_base/talloc"
+    if ! fetch_termux_pkg "libtalloc" "$deb_arch" "$talloc_dir"; then
+        return 1
+    fi
+
+    # Copy proot binary
+    local proot_bin
+    proot_bin=$(find "$proot_dir" -name "proot" -path "*/bin/*" -type f | head -1)
+    if [ -z "$proot_bin" ]; then
+        echo "  [$jni_abi] ERROR: proot binary not found"
+        return 1
+    fi
+    cp "$proot_bin" "$out_dir/libproot.so"
+    chmod 755 "$out_dir/libproot.so"
+
+    # Copy loader (64-bit or matching arch)
+    local loader
+    loader=$(find "$proot_dir" -name "loader" -not -name "loader32" -path "*/proot/*" -type f | head -1)
+    if [ -n "$loader" ]; then
+        cp "$loader" "$out_dir/libprootloader.so"
+        chmod 755 "$out_dir/libprootloader.so"
+    fi
+
+    # Copy loader32 (for 32-bit compat)
+    local loader32
+    loader32=$(find "$proot_dir" -name "loader32" -path "*/proot/*" -type f | head -1)
+    if [ -n "$loader32" ]; then
+        cp "$loader32" "$out_dir/libprootloader32.so"
+        chmod 755 "$out_dir/libprootloader32.so"
+    fi
+
+    # Copy libtalloc (renamed to lib*.so for Android packaging)
+    local talloc_lib
+    talloc_lib=$(find "$talloc_dir" -name "libtalloc.so.*" -not -name "*.py" -type f | head -1)
+    if [ -z "$talloc_lib" ]; then
+        # Try the symlink target
+        talloc_lib=$(find "$talloc_dir" -name "libtalloc.so" -type f -o -name "libtalloc.so" -type l | head -1)
+    fi
+    if [ -n "$talloc_lib" ]; then
+        # Resolve symlink and copy actual file
+        cp -L "$talloc_lib" "$out_dir/libtalloc.so"
+        chmod 755 "$out_dir/libtalloc.so"
+    else
+        echo "  [$jni_abi] WARN: libtalloc not found"
+    fi
+
+    echo "  [$jni_abi] OK — $(ls "$out_dir"/ | tr '\n' ' ')"
+}
+
+echo "=== Fetching PRoot + libtalloc from Termux packages ==="
+echo ""
+
+SUCCESS=0
+FAILED=0
+
+for entry in "arm64-v8a:aarch64"; do
+    IFS=':' read -r abi deb_arch <<< "$entry"
+
+    if fetch_for_abi "$abi" "$deb_arch"; then
+        SUCCESS=$((SUCCESS + 1))
+    else
+        echo "  [$abi] FAILED"
+        FAILED=$((FAILED + 1))
+    fi
+    echo ""
+done
+
+echo "=== Summary ==="
+echo "Success: $SUCCESS / 1"
+if [ "$FAILED" -gt 0 ]; then
+    echo "Failed: $FAILED"
+fi
+
+echo ""
+echo "Files:"
+ls -la "$JNILIBS_DIR"/*/lib*.so 2>/dev/null || echo "  (none)"

--- a/scripts/pack-openclaw-tgz.sh
+++ b/scripts/pack-openclaw-tgz.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SOURCE_DIR="$WORKSPACE_DIR/openclaw"
+OUTPUT_DIR="$WORKSPACE_DIR"
+
+if [[ ! -d "$SOURCE_DIR" ]]; then
+  echo "[pack-openclaw] Package source directory not found: $SOURCE_DIR"
+  exit 1
+fi
+
+cd "$SOURCE_DIR"
+
+log() {
+  echo "[pack-openclaw] $*"
+}
+
+log_success() {
+  local green reset
+  green="$(printf '\033[0;32m')"
+  reset="$(printf '\033[0m')"
+  echo "${green}[pack-openclaw] $*${reset}"
+}
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+ensure_apt_available() {
+  if ! has_cmd apt-get; then
+    log "apt-get not found; cannot auto-install dependencies."
+    log "Please install the following tools on Debian/Ubuntu and retry:"
+    log "  sudo apt-get update -y"
+    log "  sudo apt-get install -y curl ca-certificates gnupg"
+    log "  curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -"
+    log "  sudo apt-get install -y nodejs"
+    log "  sudo npm install -g corepack"
+    log "  corepack enable && corepack prepare pnpm@latest --activate"
+    exit 1
+  fi
+}
+
+ensure_node_22() {
+  if has_cmd node; then
+    local major
+    major="$(node -p "process.versions.node.split('.')[0]")"
+    if [[ "$major" -ge 22 ]]; then
+      log "Node.js requirement satisfied: $(node -v)"
+      return
+    fi
+    log "Node.js version too old: $(node -v), upgrading to 22.x"
+  else
+    log "Node.js not found, installing 22.x"
+  fi
+
+  ensure_apt_available
+  if [[ "${EUID}" -ne 0 ]] && ! has_cmd sudo; then
+    log "Root/sudo is required to install Node.js, but sudo is unavailable."
+    exit 1
+  fi
+
+  local run
+  if [[ "${EUID}" -eq 0 ]]; then
+    run=""
+  else
+    run="sudo"
+  fi
+
+  $run apt-get update -y
+  $run apt-get install -y ca-certificates curl gnupg
+  curl -fsSL https://deb.nodesource.com/setup_22.x | $run -E bash -
+  $run apt-get install -y nodejs
+  log "Node.js installation completed: $(node -v)"
+}
+
+ensure_npm() {
+  if has_cmd npm; then
+    log "npm is available: $(npm -v)"
+    return
+  fi
+  log "npm is missing, reinstalling via Node.js setup"
+  ensure_node_22
+  if ! has_cmd npm; then
+    log "npm is still unavailable; please verify Node.js installation manually."
+    exit 1
+  fi
+}
+
+ensure_pnpm() {
+  if has_cmd pnpm; then
+    log "pnpm is available: $(pnpm -v)"
+    return
+  fi
+
+  if ! has_cmd corepack; then
+    log "corepack is missing, installing via npm"
+    npm install -g corepack
+  fi
+
+  corepack enable
+  corepack prepare pnpm@latest --activate
+
+  if ! has_cmd pnpm; then
+    log "pnpm installation failed; please check manually."
+    exit 1
+  fi
+  log "pnpm installation completed: $(pnpm -v)"
+}
+
+install_dependencies() {
+  if [[ ! -d node_modules ]]; then
+    log "node_modules not found, installing dependencies"
+    pnpm install
+    return
+  fi
+
+  log "node_modules already exists, skipping dependency install"
+}
+
+expected_tarball_name() {
+  if ! has_cmd node; then
+    return 1
+  fi
+  node -e 'const p=require("./package.json");const n=String(p.name||"package").replace(/^@/,"").replace(/\//g,"-");const v=String(p.version||"0.0.0");console.log(`${n}-${v}.tgz`);'
+}
+
+resolve_tarball_path() {
+  local expected
+  expected="$(expected_tarball_name || true)"
+
+  if [[ -n "$expected" && -f "$SOURCE_DIR/$expected" ]]; then
+    echo "$SOURCE_DIR/$expected"
+    return 0
+  fi
+
+  local candidates=("$SOURCE_DIR"/*.tgz)
+  if [[ ${#candidates[@]} -eq 0 || ! -f "${candidates[0]}" ]]; then
+    return 1
+  fi
+
+  ls -t "$SOURCE_DIR"/*.tgz | sed -n '1p'
+}
+
+pack_tgz_once() {
+  log "Start packing openclaw (.tgz)"
+  npm pack
+}
+
+finalize_tarball() {
+  local tarball_path tarball target
+  tarball_path="$(resolve_tarball_path || true)"
+  if [[ -z "$tarball_path" || ! -f "$tarball_path" ]]; then
+    log "No .tgz file found after packing; aborting."
+    exit 1
+  fi
+
+  tarball="$(basename "$tarball_path")"
+  target="$OUTPUT_DIR/$tarball"
+  mv -f "$tarball_path" "$target"
+  log_success "Packing completed: $target"
+}
+
+main() {
+  log "Checking and preparing build environment"
+  ensure_node_22
+  ensure_npm
+  ensure_pnpm
+  install_dependencies
+
+  log "Environment is ready, running npm pack"
+  pack_tgz_once
+  finalize_tarball
+}
+
+main "$@"

--- a/scripts/update-openclaw-tgz-url.sh
+++ b/scripts/update-openclaw-tgz-url.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$SCRIPT_DIR/.."
+
+INSTALLER_FILE="$PROJECT_DIR/lib/installer.js"
+CONSTANTS_FILE="$PROJECT_DIR/flutter_app/lib/constants.dart"
+
+if [ "${1:-}" = "" ]; then
+  echo "Usage: $0 <https://.../openclaw-xxx.tgz>"
+  exit 1
+fi
+
+TGZ_URL="$1"
+
+if [[ ! "$TGZ_URL" =~ ^https?://.*\.tgz([?#].*)?$ ]]; then
+  echo "Error: URL must start with http/https and end with .tgz"
+  exit 1
+fi
+
+if [ ! -f "$INSTALLER_FILE" ] || [ ! -f "$CONSTANTS_FILE" ]; then
+  echo "Error: target files not found."
+  exit 1
+fi
+
+python3 - "$INSTALLER_FILE" "$CONSTANTS_FILE" "$TGZ_URL" <<'PY'
+import re
+import sys
+
+installer_path, constants_path, url = sys.argv[1], sys.argv[2], sys.argv[3]
+
+installer = open(installer_path, "r", encoding="utf-8").read()
+constants = open(constants_path, "r", encoding="utf-8").read()
+
+installer_new, n1 = re.subn(
+    r"(const OPENCLAW_TGZ_URL\s*=\s*')[^']+(';)",
+    rf"\1{url}\2",
+    installer,
+    count=1,
+)
+if n1 != 1:
+    print("Error: failed to update OPENCLAW_TGZ_URL in lib/installer.js")
+    sys.exit(2)
+
+constants_new, n2 = re.subn(
+    r"(static const String openclawTgzUrl\s*=\s*[\r\n]+\s*')[^']+(';)",
+    rf"\1{url}\2",
+    constants,
+    count=1,
+)
+if n2 != 1:
+    print("Error: failed to update openclawTgzUrl in flutter_app/lib/constants.dart")
+    sys.exit(3)
+
+open(installer_path, "w", encoding="utf-8").write(installer_new)
+open(constants_path, "w", encoding="utf-8").write(constants_new)
+
+print("Updated:")
+print(f" - {installer_path}")
+print(f" - {constants_path}")
+print(f"New URL: {url}")
+PY
+


### PR DESCRIPTION
这个 PR 主要做两件事：一是把 OpenClaw 的安装路径改成“优先固定 .tgz 包、失败再回退 npm 包”；二是补齐 arm64-v8a 的打包辅助脚本，让发布流程更稳定可复现。对应改动覆盖 README.md、flutter_app/lib/constants.dart、flutter_app/lib/screens/splash_screen.dart、flutter_app/lib/services/bootstrap_service.dart、lib/installer.js。

安装逻辑上，CLI 和 Flutter 两条链路都统一成同一策略：先安装固定 URL 的 OpenClaw tarball（便于锁定已验证版本），若下载或安装失败则自动回退到 npm install -g openclaw。这样可以兼顾“版本可控”和“安装兜底”，避免单点失败导致首启或 bootstrap 中断。

新增的 4 个脚本分别承担明确职责：fetch-proot-binaries-only-arm64-v8a.sh 从 Termux 包提取 proot/libtalloc 并落到 jniLibs/arm64-v8a；build-apk-only-arm64-v8a.sh 串联依赖检查与 arm64 release APK 构建；pack-openclaw-tgz.sh 规范化生成 OpenClaw .tgz（含 Node/pnpm 环境准备）；update-openclaw-tgz-url.sh 一次性同步更新 installer 与 Flutter 常量里的 tgz URL，避免手工漏改。

整体收益是把“构建 APK、生成 tgz、替换发布 URL、运行安装”串成一条可重复的发布路径，尤其面向 arm64 场景更直接。对用户侧行为几乎无破坏性变化，主要是安装来源更可控，且保留 npm fallback 作为安全网。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ARM64-specific build scripts for Android APK creation.
  * Added utility scripts for packaging and updating OpenClaw distribution.

* **Documentation**
  * Updated installation instructions with fallback mechanism for improved reliability.

* **Improvements**
  * Enhanced OpenClaw installation process with preferred .tgz source and npm package fallback.
  * Added configuration constants for OpenClaw package management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches `openclaw` installation to “fixed .tgz first, fallback to npm” across CLI and Flutter, and adds arm64-v8a packaging scripts to make releases reliable and repeatable. Locks installs to a tested build while keeping a safe fallback.

- **New Features**
  - Unified install strategy: try fixed tarball URL, then `npm install -g openclaw` (README, `lib/installer.js`, Flutter bootstrap/splash).
  - Added `flutter_app` constants for the tarball URL and npm package.
  - New scripts for arm64-v8a:
    - `fetch-proot-binaries-only-arm64-v8a.sh` – pulls `proot`/`libtalloc` from Termux into `jniLibs/arm64-v8a`.
    - `build-apk-only-arm64-v8a.sh` – builds release APK for arm64.
    - `pack-openclaw-tgz.sh` – prepares `Node.js`/`pnpm` and runs `npm pack` for a clean `.tgz`.
    - `update-openclaw-tgz-url.sh` – updates the tarball URL in both installer and Flutter constants.

- **Migration**
  - To publish a new tarball: run `scripts/pack-openclaw-tgz.sh`, upload the `.tgz`, then run `scripts/update-openclaw-tgz-url.sh <url>`.
  - To build arm64 APK: run `scripts/build-apk-only-arm64-v8a.sh` (fetches required PRoot libs automatically).
  - No breaking changes for users; npm registry remains as fallback.

<sup>Written for commit ac8b49d5cef0a6fbaa274dc4a30d443170ced8c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

