### PR TITLE
Add MiniMax AI provider

### DIFF
--- a/flutter_app/lib/models/ai_provider.dart
+++ b/flutter_app/lib/models/ai_provider.dart
@@ -133,6 +133,28 @@ class AiProvider {
     apiKeyHint: 'xai-...',
   );
 
+  static const minimax = AiProvider(
+    id: 'minimax',
+    name: 'MiniMax',
+    description: 'MiniMax models with long-context reasoning',
+    icon: Icons.all_inclusive,
+    color: Color(0xFF8B5CF6),
+    baseUrl: 'https://api.minimax.io/v1',
+    defaultModels: [
+      'MiniMax-M3',
+    ],
+    apiKeyHint: 'sk-...',
+  );
+
   /// All available AI providers.
-  static const all = [anthropic, openai, google, openrouter, nvidia, deepseek, xai];
+  static const all = [
+    anthropic,
+    openai,
+    google,
+    openrouter,
+    nvidia,
+    deepseek,
+    xai,
+    minimax,
+  ];
 }


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax to the AI provider registry.
- Configure MiniMax-M3 as the default model with the OpenAI-compatible MiniMax endpoint.

## Checks
- `git add -A -N && git diff HEAD | grep -E "$SECRET_RE"` (no matches)
- `flutter analyze` (not run: Flutter SDK not installed in environment)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MiniMax to the provider registry so users can select it in the app. Sets `MiniMax-M3` as the default model and configures the `https://api.minimax.io/v1` endpoint.

<sup>Written for commit 0a962fc1ba2d09cbf82c5ff1fbaddaae1fc4b263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mithun50/openclaw-termux/pull/142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new AI provider option, making it available in the provider list for selection.
  * Expanded the available provider choices so users can access an additional service alongside the existing options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->